### PR TITLE
Reduce allowance in transferFrom when not max value

### DIFF
--- a/contracts/src/tokens/erc20.rs
+++ b/contracts/src/tokens/erc20.rs
@@ -231,7 +231,9 @@ impl<T: ERC20Params> ERC20<T> {
                 want: amount,
             }));
         }
-        allowance.set(old_allowance - amount);
+        if old_allowance != U256::MAX {
+            allowance.set(old_allowance - amount);
+        }
         self._transfer(from, to, amount)?;
         Ok(true)
     }


### PR DESCRIPTION
Hey cygaar, your work is incredible, I bring a small contribution, the idea is adjusts the transferFrom function to decrement the allowance only when it's not set to uint256 max. This change prevents unnecessary gas usage when the allowance is already set to the maximum value.
