### PR TITLE
Export `ecrecover` feature

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -19,5 +19,8 @@ stylus-sdk = { workspace = true }
 default = ["erc20", "erc721"]
 export-abi = ["stylus-sdk/export-abi"]
 debug = ["stylus-sdk/debug"]
+# Tokens features
 erc20 = []
 erc721 = []
+# Utils features
+ecrecover = []

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -17,4 +17,5 @@ extern crate inkmate_common;
 pub mod tokens;
 
 // Utility functions and helpers used across the library
-mod utils;
+#[cfg(any(feature = "erc20", feature = "ecrecover"))]
+pub mod utils;

--- a/contracts/src/tokens/erc20.rs
+++ b/contracts/src/tokens/erc20.rs
@@ -13,8 +13,7 @@ use stylus_sdk::{
     prelude::*,
 };
 
-use crate::inkmate_common::crypto::ecrecover::EcRecoverTrait;
-use crate::utils::ecrecover::PrecompileEcRecover;
+use crate::utils::ecrecover::{EcRecoverTrait, PrecompileEcRecover};
 
 pub trait ERC20Params {
     const NAME: &'static str;

--- a/contracts/src/utils/ecrecover.rs
+++ b/contracts/src/utils/ecrecover.rs
@@ -1,10 +1,14 @@
 //! Calls the ecrecover EVM precompile through a static call and returns the recovered address
 
 use crate::inkmate_common::crypto::ecrecover::{
-    EcRecoverTrait, EcdsaError, EC_RECOVER_ADDRESS_LAST_BYTE, EC_RECOVER_INPUT_LEN,
-    NUM_BYTES_ADDRESS, NUM_BYTES_U256,
+    EcdsaError, EC_RECOVER_ADDRESS_LAST_BYTE, EC_RECOVER_INPUT_LEN, NUM_BYTES_ADDRESS,
+    NUM_BYTES_U256,
 };
 use stylus_sdk::{alloy_primitives::Address, call::RawCall};
+
+/// Import EcRecoverTrait from inkmate_common publicly
+/// This permit projects to use it without importing `inkmate_common`
+pub use crate::inkmate_common::crypto::ecrecover::EcRecoverTrait;
 
 pub struct PrecompileEcRecover;
 

--- a/contracts/src/utils/mod.rs
+++ b/contracts/src/utils/mod.rs
@@ -1,4 +1,4 @@
 //! Various utilities used throughout the contracts
 
-#[cfg(any(feature = "erc20",))]
+#[cfg(any(feature = "erc20", feature = "ecrecover"))]
 pub mod ecrecover;


### PR DESCRIPTION
## Description

The goal of this PR is to expose the ecrecover feature to other project 

Changes:

 - Export the `PrecompiledEcRecover` trait via a new `ecrecover` feature.
 - Re-export the `EcRecoverTrait` from `contracts/src/utils/recover.rs` trait to let importing project use `PrecompiledEcRecover` via a dependency on `inkmate` without needing to install `inkmate-common`
 - Use re-exported `EcRecoverTrait` inside `contracts/src/tokens/erc20.rs`

## Checklist

- [ ] I have documented these changes where necessary.
- [ ] I have read the [DCO][DCO] and ensured that these changes comply.
- [ ] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-hello-world/blob/main/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-hello-world/blob/main/licenses/COPYRIGHT.md
